### PR TITLE
Don't box handler errors

### DIFF
--- a/examples/error_handling.rs
+++ b/examples/error_handling.rs
@@ -23,9 +23,9 @@ fn format_cause_chain(err: impl std::error::Error) -> String {
     lines.join("\n")
 }
 
-// Define an error handler function which will accept the `routerify::Error`
+// Define an error handler function which will accept the `routerify::RouterError`
 // and generates an appropriate response.
-async fn error_handler(err: routerify::Error) -> Response<Body> {
+async fn error_handler(err: routerify::RouterError<io::Error>) -> Response<Body> {
     Response::builder()
         .status(StatusCode::INTERNAL_SERVER_ERROR)
         .body(Body::from(format_cause_chain(err)))

--- a/examples/error_handling_with_request_info.rs
+++ b/examples/error_handling_with_request_info.rs
@@ -13,9 +13,9 @@ async fn about_handler(_: Request<Body>) -> Result<Response<Body>, io::Error> {
     Ok(Response::new(Body::from("About page")))
 }
 
-// Define an error handler function which will accept the `routerify::Error` and the `req_info`
+// Define an error handler function which will accept the `routerify::RouterError` and the `req_info`
 // and generates an appropriate response.
-async fn error_handler(err: routerify::Error, req_info: RequestInfo) -> Response<Body> {
+async fn error_handler(err: routerify::RouterError<io::Error>, req_info: RequestInfo) -> Response<Body> {
     eprintln!("{}", err);
 
     // Access a cookie.

--- a/examples/share_data_and_state.rs
+++ b/examples/share_data_and_state.rs
@@ -27,9 +27,9 @@ async fn logger(req: Request<Body>) -> Result<Request<Body>, Infallible> {
     Ok(req)
 }
 
-// Define an error handler function which will accept the `routerify::Error`
+// Define an error handler function which will accept the `routerify::RouterError`
 // and the request information and generates an appropriate response.
-async fn error_handler(err: routerify::Error, req_info: RequestInfo) -> Response<Body> {
+async fn error_handler(err: routerify::RouterError<Infallible>, req_info: RequestInfo) -> Response<Body> {
     // You can also access the same state from error handler.
     let state = req_info.data::<State>().unwrap();
     println!("State value: {}", state.0);

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,6 @@
 /// The error type used by the `Routerify` library.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("Couldn't decode the request path as UTF8")]
-    DecodeRequestPath(#[source] std::str::Utf8Error),
-
     #[error("Couldn't create router RegexSet")]
     CreateRouterRegexSet(#[source] regex::Error),
 
@@ -12,19 +9,32 @@ pub enum Error {
 
     #[error("Could not create an exact match regex for the route path: {1}")]
     GeneratePrefixMatchRegex(#[source] regex::Error, String),
+}
+
+/// The error type used by `routerify::Router` for request error handling
+#[derive(thiserror::Error, Debug)]
+pub enum RouterError<E: HandlerError + 'static> {
+    #[error("Couldn't decode the request path as UTF8")]
+    DecodeRequestPath(#[source] std::str::Utf8Error),
 
     #[error("No handlers added to handle non-existent routes. Tips: Please add an '.any' route at the bottom to handle any routes.")]
     HandleNonExistentRoute,
 
     #[error("A route was unable to handle the pre middleware request")]
-    HandlePreMiddlewareRequest(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+    HandlePreMiddlewareRequest(#[source] E),
 
     #[error("A route was unable to handle the request for target: {1}")]
-    HandleRequest(#[source] Box<dyn std::error::Error + Send + Sync + 'static>, String),
+    HandleRequest(#[source] E, String),
 
     #[error("One of the post middlewares (without info) couldn't process the response")]
-    HandlePostMiddlewareWithoutInfoRequest(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+    HandlePostMiddlewareWithoutInfoRequest(#[source] E),
 
     #[error("One of the post middlewares (with info) couldn't process the response")]
-    HandlePostMiddlewareWithInfoRequest(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+    HandlePostMiddlewareWithInfoRequest(#[source] E),
 }
+
+/// Errors which originate in user provided handlers must implement this trait
+/// A blanket implementation is provided that should apply in most cases
+pub trait HandlerError: std::error::Error + Unpin + Send + Sync {}
+
+impl<T> HandlerError for T where T: std::error::Error + Unpin + Send + Sync {}

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -1,5 +1,4 @@
 use crate::types::RequestMeta;
-use crate::Error;
 use http::Extensions;
 use percent_encoding::percent_decode_str;
 
@@ -11,11 +10,8 @@ pub(crate) fn update_req_meta_in_extensions(ext: &mut Extensions, new_req_meta: 
     }
 }
 
-pub(crate) fn percent_decode_request_path(val: &str) -> crate::Result<String> {
-    percent_decode_str(val)
-        .decode_utf8()
-        .map_err(Error::DecodeRequestPath)
-        .map(|val| val.to_string())
+pub(crate) fn percent_decode_request_path(val: &str) -> Result<String, std::str::Utf8Error> {
+    percent_decode_str(val).decode_utf8().map(|val| val.to_string())
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@
 //!
 //! // Define an error handler function which will accept the `routerify::Error`
 //! // and the request information and generates an appropriate response.
-//! async fn error_handler(err: routerify::Error, _: RequestInfo) -> Response<Body> {
+//! async fn error_handler(err: routerify::RouterError<Infallible>, _: RequestInfo) -> Response<Body> {
 //!     eprintln!("{}", err);
 //!     Response::builder()
 //!         .status(StatusCode::INTERNAL_SERVER_ERROR)
@@ -525,7 +525,7 @@
 //!
 //! // Define an error handler function which will accept the `routerify::Error`
 //! // and the request information and generates an appropriate response.
-//! async fn error_handler(err: routerify::Error, req_info: RequestInfo) -> Response<Body> {
+//! async fn error_handler(err: routerify::RouterError<Infallible>, req_info: RequestInfo) -> Response<Body> {
 //!     // You can also access the same state from error handler.
 //!     let state = req_info.data::<State>().unwrap();
 //!     println!("State value: {}", state.0);
@@ -706,17 +706,18 @@
 //! use routerify::{Router, Middleware};
 //! use routerify::prelude::*;
 //! use hyper::{Response, Body, StatusCode};
+//! use std::convert::Infallible;
 //!
 //! // The error handler will accept the thrown error in routerify::Error type and
 //! // it will have to generate a response based on the error.
-//! async fn error_handler(err: routerify::Error) -> Response<Body> {
+//! async fn error_handler(err: routerify::RouterError<Infallible>) -> Response<Body> {
 //!     Response::builder()
 //!       .status(StatusCode::INTERNAL_SERVER_ERROR)
 //!       .body(Body::from("Something went wrong"))
 //!       .unwrap()
 //! }
 //!
-//! # fn run() -> Router<Body, hyper::Error> {
+//! # fn run() -> Router<Body, Infallible> {
 //! let router = Router::builder()
 //!      .get("/users", |req| async move { Ok(Response::new(Body::from("It might raise an error"))) })
 //!      // Here attach the custom error handler defined above.
@@ -737,10 +738,11 @@
 //! use routerify::{Router, Middleware, RequestInfo};
 //! use routerify::prelude::*;
 //! use hyper::{Response, Body, StatusCode};
+//! use std::convert::Infallible;
 //!
 //! // The error handler will accept the thrown error and the request info and
 //! // it will generate a response.
-//! async fn error_handler(err: routerify::Error, req_info: RequestInfo) -> Response<Body> {
+//! async fn error_handler(err: routerify::RouterError<Infallible>, req_info: RequestInfo) -> Response<Body> {
 //!     // Now generate response based on the `err` and the `req_info`.
 //!     Response::builder()
 //!       .status(StatusCode::INTERNAL_SERVER_ERROR)
@@ -748,7 +750,7 @@
 //!       .unwrap()
 //! }
 //!
-//! # fn run() -> Router<Body, hyper::Error> {
+//! # fn run() -> Router<Body, Infallible> {
 //! let router = Router::builder()
 //!      .get("/users", |req| async move { Ok(Response::new(Body::from("It might raise an error"))) })
 //!      // Now register this error handler.
@@ -760,7 +762,7 @@
 //! # run();
 //! ```
 
-pub use self::error::Error;
+pub use self::error::{Error, HandlerError, RouterError};
 pub use self::middleware::{Middleware, PostMiddleware, PreMiddleware};
 pub use self::route::Route;
 pub use self::router::{Router, RouterBuilder};

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -4,6 +4,7 @@ use std::future::Future;
 
 pub use self::post::PostMiddleware;
 pub use self::pre::PreMiddleware;
+use crate::HandlerError;
 
 mod post;
 mod pre;
@@ -17,7 +18,7 @@ mod pre;
 ///   type.
 /// * The `E` represents any error type which will be used by route handlers and the middlewares. This error type must implement the [std::error::Error](https://doc.rust-lang.org/std/error/trait.Error.html).
 #[derive(Debug)]
-pub enum Middleware<B, E> {
+pub enum Middleware<B, E: HandlerError + 'static> {
     /// Variant for the pre middleware. Refer to [Pre Middleware](./index.html#pre-middleware) for more info.
     Pre(PreMiddleware<E>),
 

--- a/src/route/mod.rs
+++ b/src/route/mod.rs
@@ -1,7 +1,6 @@
-use crate::helpers;
 use crate::regex_generator::generate_exact_match_regex;
 use crate::types::{RequestMeta, RouteParams};
-use crate::Error;
+use crate::{helpers, HandlerError};
 use hyper::{body::HttpBody, Method, Request, Response};
 use regex::Regex;
 use std::fmt::{self, Debug, Formatter};
@@ -53,7 +52,7 @@ pub struct Route<B, E> {
     pub(crate) methods: Vec<Method>,
 }
 
-impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + Sync + Unpin + 'static> Route<B, E> {
+impl<B: HttpBody + Send + Sync + Unpin + 'static, E: HandlerError + 'static> Route<B, E> {
     pub(crate) fn new_with_boxed_handler<P: Into<String>>(
         path: P,
         methods: Vec<Method>,
@@ -85,33 +84,26 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
         self.methods.contains(method)
     }
 
-    pub(crate) async fn process(
-        &mut self,
-        target_path: &str,
-        mut req: Request<hyper::Body>,
-    ) -> crate::Result<Response<B>> {
-        self.push_req_meta(target_path, &mut req)?;
+    pub(crate) async fn process(&mut self, target_path: &str, mut req: Request<hyper::Body>) -> Result<Response<B>, E> {
+        self.push_req_meta(target_path, &mut req);
 
         let handler = self
             .handler
             .as_mut()
             .expect("A router can not be used after mounting into another router");
 
-        Pin::from(handler(req))
-            .await
-            .map_err(|e| Error::HandleRequest(e.into(), target_path.into()))
+        Pin::from(handler(req)).await
     }
 
-    fn push_req_meta(&self, target_path: &str, req: &mut Request<hyper::Body>) -> crate::Result<()> {
-        self.update_req_meta(req, self.generate_req_meta(target_path)?);
-        Ok(())
+    fn push_req_meta(&self, target_path: &str, req: &mut Request<hyper::Body>) {
+        self.update_req_meta(req, self.generate_req_meta(target_path));
     }
 
     fn update_req_meta(&self, req: &mut Request<hyper::Body>, req_meta: RequestMeta) {
         helpers::update_req_meta_in_extensions(req.extensions_mut(), req_meta);
     }
 
-    fn generate_req_meta(&self, target_path: &str) -> crate::Result<RequestMeta> {
+    fn generate_req_meta(&self, target_path: &str) -> RequestMeta {
         let route_params_list = &self.route_params;
         let ln = route_params_list.len();
 
@@ -127,7 +119,7 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
             }
         }
 
-        Ok(RequestMeta::with_route_params(route_params))
+        RequestMeta::with_route_params(route_params)
     }
 }
 

--- a/src/service/request_service.rs
+++ b/src/service/request_service.rs
@@ -1,31 +1,25 @@
-use crate::helpers;
 use crate::router::Router;
 use crate::types::{RequestInfo, RequestMeta};
+use crate::{helpers, HandlerError, RouterError};
 use hyper::{body::HttpBody, service::Service, Request, Response};
 use std::future::Future;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-pub struct RequestService<B, E> {
+pub struct RequestService<B, E: HandlerError + 'static> {
     pub(crate) router: *mut Router<B, E>,
     pub(crate) remote_addr: SocketAddr,
 }
 
-unsafe impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + Sync + Unpin + 'static> Send
-    for RequestService<B, E>
-{
-}
-unsafe impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + Sync + Unpin + 'static> Sync
-    for RequestService<B, E>
-{
-}
+unsafe impl<B: HttpBody + Send + Sync + Unpin + 'static, E: HandlerError> Send for RequestService<B, E> {}
+unsafe impl<B: HttpBody + Send + Sync + Unpin + 'static, E: HandlerError> Sync for RequestService<B, E> {}
 
-impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + Sync + Unpin + 'static>
-    Service<Request<hyper::Body>> for RequestService<B, E>
+impl<B: HttpBody + Send + Sync + Unpin + 'static, E: HandlerError> Service<Request<hyper::Body>>
+    for RequestService<B, E>
 {
     type Response = Response<B>;
-    type Error = crate::Error;
+    type Error = RouterError<E>;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
 
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
@@ -39,7 +33,8 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
         let fut = async move {
             helpers::update_req_meta_in_extensions(req.extensions_mut(), RequestMeta::with_remote_addr(remote_addr));
 
-            let mut target_path = helpers::percent_decode_request_path(req.uri().path())?;
+            let mut target_path =
+                helpers::percent_decode_request_path(req.uri().path()).map_err(RouterError::DecodeRequestPath)?;
 
             if target_path.as_bytes()[target_path.len() - 1] != b'/' {
                 target_path.push_str("/");
@@ -55,12 +50,12 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
             }
 
             match router.process(target_path.as_str(), req, req_info.clone()).await {
-                Ok(resp) => crate::Result::Ok(resp),
+                Ok(resp) => Ok(resp),
                 Err(err) => {
                     if let Some(ref mut err_handler) = router.err_handler {
-                        crate::Result::Ok(err_handler.execute(err, req_info.clone()).await)
+                        Ok(err_handler.execute(err, req_info.clone()).await)
                     } else {
-                        crate::Result::Err(err)
+                        Err(err)
                     }
                 }
             }


### PR DESCRIPTION
Split `crate::Error` into `crate::Error` and `crate::RouterError<E>`, where `E` is the custom error type already associated with the Router.

The intent is to allow matching of errors returned by middlewares and route handlers within the global error_handler, without having to write custom handler shims.

Unfortunately the nature of the thiserror proc macro forces the type and lifetime constraint to be on the struct definition, which is a touch unfortunate, but makes little difference in practice.

This is a breaking change as it changes the signature of the error_handler functions, but this should be the extent of the breakage