### PR TITLE
Only require convertibility from handler error type to router error type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ default = []
 all = []
 
 [dependencies]
+futures-util = "0.3"
 hyper = { version = "0.14", default-features = false, features = ["full"] }
 http = "0.2"
 regex = "1"

--- a/examples/test-with-heavy-loads.rs
+++ b/examples/test-with-heavy-loads.rs
@@ -1,28 +1,29 @@
 use hyper::{Body, Response, Server};
 use routerify::{Middleware, Router, RouterService};
 use std::net::SocketAddr;
+use std::convert::Infallible;
 
-fn router() -> Router<Body, routerify::Error> {
+fn router() -> Router<Body, Infallible> {
     let mut builder = Router::builder();
 
     for i in 0..3000_usize {
         builder = builder.middleware(
             Middleware::pre_with_path(format!("/abc-{}", i), move |req| async move {
                 // println!("PreMiddleware: {}", format!("/abc-{}", i));
-                Ok(req)
+                Ok::<_, Infallible>(req)
             })
             .unwrap(),
         );
 
         builder = builder.get(format!("/abc-{}", i), move |_req| async move {
             // println!("Route: {}, params: {:?}", format!("/abc-{}", i), req.params());
-            Ok(Response::new(Body::from(format!("/abc-{}", i))))
+            Ok::<_, Infallible>(Response::new(Body::from(format!("/abc-{}", i))))
         });
 
         builder = builder.middleware(
             Middleware::post_with_path(format!("/abc-{}", i), move |res| async move {
                 // println!("PostMiddleware: {}", format!("/abc-{}", i));
-                Ok(res)
+                Ok::<_, Infallible>(res)
             })
             .unwrap(),
         );

--- a/examples/test2.rs
+++ b/examples/test2.rs
@@ -53,7 +53,7 @@ fn router2() -> Router<Body, Error> {
             println!("Router2 Data: {:?}", req.data::<&str>());
             println!("Router2 Data: {:?}", req.data::<State>().map(|s| s.0));
             println!("Router2 Data: {:?}", req.data::<u32>());
-            Ok(Response::new(Body::from("Hello world!")))
+            Ok::<_, Error>(Response::new(Body::from("Hello world!")))
         })
         .build()
         .unwrap()
@@ -66,7 +66,7 @@ fn router3() -> Router<Body, Error> {
             println!("Router3 Data: {:?}", req.data::<&str>());
             println!("Router3 Data: {:?}", req.data::<State>().map(|s| s.0));
             println!("Router3 Data: {:?}", req.data::<u32>());
-            Ok(Response::new(Body::from("Hello world!")))
+            Ok::<_, Error>(Response::new(Body::from("Hello world!")))
         })
         .build()
         .unwrap()

--- a/src/ext/request.rs
+++ b/src/ext/request.rs
@@ -22,7 +22,7 @@ pub trait RequestExt {
     ///         let user_name = params.get("userName").unwrap();
     ///         let book_name = params.get("bookName").unwrap();
     ///
-    ///         Ok(Response::new(Body::from(format!("Username: {}, Book Name: {}", user_name, book_name))))
+    ///         Ok::<_, Infallible>(Response::new(Body::from(format!("Username: {}, Book Name: {}", user_name, book_name))))
     ///      })
     ///      .build()
     ///      .unwrap();
@@ -48,7 +48,7 @@ pub trait RequestExt {
     ///         let user_name = req.param("userName").unwrap();
     ///         let book_name = req.param("bookName").unwrap();
     ///
-    ///         Ok(Response::new(Body::from(format!("Username: {}, Book Name: {}", user_name, book_name))))
+    ///         Ok::<_, Infallible>(Response::new(Body::from(format!("Username: {}, Book Name: {}", user_name, book_name))))
     ///      })
     ///      .build()
     ///      .unwrap();
@@ -73,7 +73,7 @@ pub trait RequestExt {
     ///     .get("/hello", |req| async move {
     ///         let remote_addr = req.remote_addr();
     ///
-    ///         Ok(Response::new(Body::from(format!("Hello from : {}", remote_addr))))
+    ///         Ok::<_, Infallible>(Response::new(Body::from(format!("Hello from : {}", remote_addr))))
     ///      })
     ///      .build()
     ///      .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@
 //!
 //! # fn run() -> Router<Body, Infallible> {
 //! let router = Router::builder()
-//!     .get("/about", |req| async move { Ok(Response::new(Body::from("About page"))) })
+//!     .get("/about", |req| async move { Ok::<_, Infallible>(Response::new(Body::from("About page"))) })
 //!     .build()
 //!     .unwrap();
 //! # router
@@ -186,7 +186,7 @@
 //!
 //! # fn run() -> Router<Body, Infallible> {
 //! let router = Router::builder()
-//!     .get("/about", |req| async move { Ok(Response::new(Body::from("About page"))) })
+//!     .get("/about", |req| async move { Ok::<_, Infallible>(Response::new(Body::from("About page"))) })
 //!     .build()
 //!     .unwrap();
 //! # router
@@ -203,7 +203,7 @@
 //!
 //! # fn run() -> Router<Body, Infallible> {
 //! let router = Router::builder()
-//!     .get("/users/*", |req| async move { Ok(Response::new(Body::from("It will match /users/, /users/any_path"))) })
+//!     .get("/users/*", |req| async move { Ok::<_, Infallible>(Response::new(Body::from("It will match /users/, /users/any_path"))) })
 //!     .build()
 //!     .unwrap();
 //! # router
@@ -218,14 +218,14 @@
 //! ```
 //! use routerify::Router;
 //! use hyper::{Response, Body, StatusCode};
-//! # use std::convert::Infallible;
+//! use std::convert::Infallible;
 //!
 //! # fn run() -> Router<Body, Infallible> {
 //! let router = Router::builder()
-//!     .get("/users", |req| async move { Ok(Response::new(Body::from("User List"))) })
+//!     .get("/users", |req| async move { Ok::<_, Infallible>(Response::new(Body::from("User List"))) })
 //!     // It fallbacks to the following route for any non-existent routes.
 //!     .any(|_req| async move {
-//!         Ok(
+//!         Ok::<_, Infallible>(
 //!             Response::builder()
 //!             .status(StatusCode::NOT_FOUND)
 //!             .body(Body::from("NOT FOUND"))
@@ -265,7 +265,7 @@
 //!         let user_name = req.param("userName").unwrap();
 //!         let book_name = req.param("bookName").unwrap();
 //!
-//!         Ok(Response::new(Body::from(format!("Username: {}, Book Name: {}", user_name, book_name))))
+//!         Ok::<_, Infallible>(Response::new(Body::from(format!("Username: {}, Book Name: {}", user_name, book_name))))
 //!      })
 //!      .build()
 //!      .unwrap();
@@ -289,9 +289,9 @@
 //!
 //! fn api_router() -> Router<Body, Infallible> {
 //!     Router::builder()
-//!         .get("/books", |req| async move { Ok(Response::new(Body::from("List of books"))) })
+//!         .get("/books", |req| async move { Ok::<_, Infallible>(Response::new(Body::from("List of books"))) })
 //!         .get("/books/:bookId", |req| async move {
-//!             Ok(Response::new(Body::from(format!("Show book: {}", req.param("bookId").unwrap()))))
+//!             Ok::<_, Infallible>(Response::new(Body::from(format!("Show book: {}", req.param("bookId").unwrap()))))
 //!          })
 //!         .build()
 //!         .unwrap()
@@ -719,7 +719,7 @@
 //!
 //! # fn run() -> Router<Body, Infallible> {
 //! let router = Router::builder()
-//!      .get("/users", |req| async move { Ok(Response::new(Body::from("It might raise an error"))) })
+//!      .get("/users", |req| async move { Ok::<_, Infallible>(Response::new(Body::from("It might raise an error"))) })
 //!      // Here attach the custom error handler defined above.
 //!      .err_handler(error_handler)
 //!      .build()
@@ -752,7 +752,7 @@
 //!
 //! # fn run() -> Router<Body, Infallible> {
 //! let router = Router::builder()
-//!      .get("/users", |req| async move { Ok(Response::new(Body::from("It might raise an error"))) })
+//!      .get("/users", |req| async move { Ok::<_, Infallible>(Response::new(Body::from("It might raise an error"))) })
 //!      // Now register this error handler.
 //!      .err_handler_with_info(error_handler)
 //!      .build()

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -40,17 +40,18 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
     ///
     /// # fn run() -> Router<Body, Infallible> {
     /// let router = Router::builder()
-    ///      .middleware(Middleware::pre(|req| async move { /* Do some operations */ Ok(req) }))
+    ///      .middleware(Middleware::pre(|req| async move { /* Do some operations */ Ok::<_, Infallible>(req) }))
     ///      .build()
     ///      .unwrap();
     /// # router
     /// # }
     /// # run();
     /// ```
-    pub fn pre<H, R>(handler: H) -> Middleware<B, E>
+    pub fn pre<H, R, EF>(handler: H) -> Middleware<B, E>
     where
         H: FnMut(Request<hyper::Body>) -> R + Send + Sync + 'static,
-        R: Future<Output = Result<Request<hyper::Body>, E>> + Send + 'static,
+        R: Future<Output = Result<Request<hyper::Body>, EF>> + Send + 'static,
+        EF: Into<E>
     {
         Middleware::pre_with_path("/*", handler).unwrap()
     }
@@ -66,17 +67,18 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
     ///
     /// # fn run() -> Router<Body, Infallible> {
     /// let router = Router::builder()
-    ///      .middleware(Middleware::post(|res| async move { /* Do some operations */ Ok(res) }))
+    ///      .middleware(Middleware::post(|res| async move { /* Do some operations */ Ok::<_, Infallible>(res) }))
     ///      .build()
     ///      .unwrap();
     /// # router
     /// # }
     /// # run();
     /// ```
-    pub fn post<H, R>(handler: H) -> Middleware<B, E>
+    pub fn post<H, R, EF>(handler: H) -> Middleware<B, E>
     where
         H: FnMut(Response<B>) -> R + Send + Sync + 'static,
-        R: Future<Output = Result<Response<B>, E>> + Send + 'static,
+        R: Future<Output = Result<Response<B>, EF>> + Send + 'static,
+        EF: Into<E>
     {
         Middleware::post_with_path("/*", handler).unwrap()
     }
@@ -108,10 +110,11 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
     /// # }
     /// # run();
     /// ```
-    pub fn post_with_info<H, R>(handler: H) -> Middleware<B, E>
+    pub fn post_with_info<H, R, EF>(handler: H) -> Middleware<B, E>
     where
         H: FnMut(Response<B>, RequestInfo) -> R + Send + Sync + 'static,
-        R: Future<Output = Result<Response<B>, E>> + Send + 'static,
+        R: Future<Output = Result<Response<B>, EF>> + Send + 'static,
+        EF: Into<E>
     {
         Middleware::post_with_info_with_path("/*", handler).unwrap()
     }
@@ -127,18 +130,19 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
     ///
     /// # fn run() -> Router<Body, Infallible> {
     /// let router = Router::builder()
-    ///      .middleware(Middleware::pre_with_path("/my-path", |req| async move { /* Do some operations */ Ok(req) }).unwrap())
+    ///      .middleware(Middleware::pre_with_path("/my-path", |req| async move { /* Do some operations */ Ok::<_, Infallible>(req) }).unwrap())
     ///      .build()
     ///      .unwrap();
     /// # router
     /// # }
     /// # run();
     /// ```
-    pub fn pre_with_path<P, H, R>(path: P, handler: H) -> crate::Result<Middleware<B, E>>
+    pub fn pre_with_path<P, H, R, EF>(path: P, handler: H) -> crate::Result<Middleware<B, E>>
     where
         P: Into<String>,
         H: FnMut(Request<hyper::Body>) -> R + Send + Sync + 'static,
-        R: Future<Output = Result<Request<hyper::Body>, E>> + Send + 'static,
+        R: Future<Output = Result<Request<hyper::Body>, EF>> + Send + 'static,
+        EF: Into<E>
     {
         Ok(Middleware::Pre(PreMiddleware::new(path, handler)?))
     }
@@ -154,18 +158,19 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
     ///
     /// # fn run() -> Router<Body, Infallible> {
     /// let router = Router::builder()
-    ///      .middleware(Middleware::post_with_path("/my-path", |res| async move { /* Do some operations */ Ok(res) }).unwrap())
+    ///      .middleware(Middleware::post_with_path("/my-path", |res| async move { /* Do some operations */ Ok::<_, Infallible>(res) }).unwrap())
     ///      .build()
     ///      .unwrap();
     /// # router
     /// # }
     /// # run();
     /// ```
-    pub fn post_with_path<P, H, R>(path: P, handler: H) -> crate::Result<Middleware<B, E>>
+    pub fn post_with_path<P, H, R, EF>(path: P, handler: H) -> crate::Result<Middleware<B, E>>
     where
         P: Into<String>,
         H: FnMut(Response<B>) -> R + Send + Sync + 'static,
-        R: Future<Output = Result<Response<B>, E>> + Send + 'static,
+        R: Future<Output = Result<Response<B>, EF>> + Send + 'static,
+        EF: Into<E>
     {
         Ok(Middleware::Post(PostMiddleware::new(path, handler)?))
     }
@@ -197,11 +202,12 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
     /// # }
     /// # run();
     /// ```
-    pub fn post_with_info_with_path<P, H, R>(path: P, handler: H) -> crate::Result<Middleware<B, E>>
+    pub fn post_with_info_with_path<P, H, R, EF>(path: P, handler: H) -> crate::Result<Middleware<B, E>>
     where
         P: Into<String>,
         H: FnMut(Response<B>, RequestInfo) -> R + Send + Sync + 'static,
-        R: Future<Output = Result<Response<B>, E>> + Send + 'static,
+        R: Future<Output = Result<Response<B>, EF>> + Send + 'static,
+        EF: Into<E>
     {
         Ok(Middleware::Post(PostMiddleware::new_with_info(path, handler)?))
     }

--- a/src/router/builder.rs
+++ b/src/router/builder.rs
@@ -125,11 +125,12 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: HandlerError> RouterBuilder
     /// # }
     /// # run();
     /// ```
-    pub fn get<P, H, R>(self, path: P, handler: H) -> Self
+    pub fn get<P, H, R, EF>(self, path: P, handler: H) -> Self
     where
         P: Into<String>,
         H: FnMut(Request<hyper::Body>) -> R + Send + Sync + 'static,
-        R: Future<Output = Result<Response<B>, E>> + Send + 'static,
+        R: Future<Output = Result<Response<B>, EF>> + Send + 'static,
+        EF: Into<E>
     {
         self.add(path, vec![Method::GET], handler)
     }
@@ -155,11 +156,12 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: HandlerError> RouterBuilder
     /// # }
     /// # run();
     /// ```
-    pub fn get_or_head<P, H, R>(self, path: P, handler: H) -> Self
+    pub fn get_or_head<P, H, R, EF>(self, path: P, handler: H) -> Self
     where
         P: Into<String>,
         H: FnMut(Request<hyper::Body>) -> R + Send + Sync + 'static,
-        R: Future<Output = Result<Response<B>, E>> + Send + 'static,
+        R: Future<Output = Result<Response<B>, EF>> + Send + 'static,
+        EF: Into<E>
     {
         self.add(path, vec![Method::GET, Method::HEAD], handler)
     }
@@ -185,11 +187,12 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: HandlerError> RouterBuilder
     /// # }
     /// # run();
     /// ```
-    pub fn post<P, H, R>(self, path: P, handler: H) -> Self
+    pub fn post<P, H, R, EF>(self, path: P, handler: H) -> Self
     where
         P: Into<String>,
         H: FnMut(Request<hyper::Body>) -> R + Send + Sync + 'static,
-        R: Future<Output = Result<Response<B>, E>> + Send + 'static,
+        R: Future<Output = Result<Response<B>, EF>> + Send + 'static,
+        EF: Into<E>
     {
         self.add(path, vec![Method::POST], handler)
     }
@@ -215,11 +218,12 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: HandlerError> RouterBuilder
     /// # }
     /// # run();
     /// ```
-    pub fn put<P, H, R>(self, path: P, handler: H) -> Self
+    pub fn put<P, H, R, EF>(self, path: P, handler: H) -> Self
     where
         P: Into<String>,
         H: FnMut(Request<hyper::Body>) -> R + Send + Sync + 'static,
-        R: Future<Output = Result<Response<B>, E>> + Send + 'static,
+        R: Future<Output = Result<Response<B>, EF>> + Send + 'static,
+        EF: Into<E>,
     {
         self.add(path, vec![Method::PUT], handler)
     }
@@ -245,11 +249,12 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: HandlerError> RouterBuilder
     /// # }
     /// # run();
     /// ```
-    pub fn delete<P, H, R>(self, path: P, handler: H) -> Self
+    pub fn delete<P, H, R, EF>(self, path: P, handler: H) -> Self
     where
         P: Into<String>,
         H: FnMut(Request<hyper::Body>) -> R + Send + Sync + 'static,
-        R: Future<Output = Result<Response<B>, E>> + Send + 'static,
+        R: Future<Output = Result<Response<B>, EF>> + Send + 'static,
+        EF: Into<E>
     {
         self.add(path, vec![Method::DELETE], handler)
     }
@@ -275,11 +280,12 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: HandlerError> RouterBuilder
     /// # }
     /// # run();
     /// ```
-    pub fn head<P, H, R>(self, path: P, handler: H) -> Self
+    pub fn head<P, H, R, EF>(self, path: P, handler: H) -> Self
     where
         P: Into<String>,
         H: FnMut(Request<hyper::Body>) -> R + Send + Sync + 'static,
-        R: Future<Output = Result<Response<B>, E>> + Send + 'static,
+        R: Future<Output = Result<Response<B>, EF>> + Send + 'static,
+        EF: Into<E>
     {
         self.add(path, vec![Method::HEAD], handler)
     }
@@ -305,11 +311,12 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: HandlerError> RouterBuilder
     /// # }
     /// # run();
     /// ```
-    pub fn trace<P, H, R>(self, path: P, handler: H) -> Self
+    pub fn trace<P, H, R, EF>(self, path: P, handler: H) -> Self
     where
         P: Into<String>,
         H: FnMut(Request<hyper::Body>) -> R + Send + Sync + 'static,
-        R: Future<Output = Result<Response<B>, E>> + Send + 'static,
+        R: Future<Output = Result<Response<B>, EF>> + Send + 'static,
+        EF: Into<E>
     {
         self.add(path, vec![Method::TRACE], handler)
     }
@@ -335,11 +342,12 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: HandlerError> RouterBuilder
     /// # }
     /// # run();
     /// ```
-    pub fn connect<P, H, R>(self, path: P, handler: H) -> Self
+    pub fn connect<P, H, R, EF>(self, path: P, handler: H) -> Self
     where
         P: Into<String>,
         H: FnMut(Request<hyper::Body>) -> R + Send + Sync + 'static,
-        R: Future<Output = Result<Response<B>, E>> + Send + 'static,
+        R: Future<Output = Result<Response<B>, EF>> + Send + 'static,
+        EF: Into<E>
     {
         self.add(path, vec![Method::CONNECT], handler)
     }
@@ -365,11 +373,12 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: HandlerError> RouterBuilder
     /// # }
     /// # run();
     /// ```
-    pub fn patch<P, H, R>(self, path: P, handler: H) -> Self
+    pub fn patch<P, H, R, EF>(self, path: P, handler: H) -> Self
     where
         P: Into<String>,
         H: FnMut(Request<hyper::Body>) -> R + Send + Sync + 'static,
-        R: Future<Output = Result<Response<B>, E>> + Send + 'static,
+        R: Future<Output = Result<Response<B>, EF>> + Send + 'static,
+        EF: Into<E>
     {
         self.add(path, vec![Method::PATCH], handler)
     }
@@ -395,11 +404,12 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: HandlerError> RouterBuilder
     /// # }
     /// # run();
     /// ```
-    pub fn options<P, H, R>(self, path: P, handler: H) -> Self
+    pub fn options<P, H, R, EF>(self, path: P, handler: H) -> Self
     where
         P: Into<String>,
         H: FnMut(Request<hyper::Body>) -> R + Send + Sync + 'static,
-        R: Future<Output = Result<Response<B>, E>> + Send + 'static,
+        R: Future<Output = Result<Response<B>, EF>> + Send + 'static,
+        EF: Into<E>
     {
         self.add(path, vec![Method::OPTIONS], handler)
     }
@@ -436,10 +446,11 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: HandlerError> RouterBuilder
     /// # }
     /// # run();
     /// ```
-    pub fn any<H, R>(self, handler: H) -> Self
+    pub fn any<H, R, EF>(self, handler: H) -> Self
     where
         H: FnMut(Request<hyper::Body>) -> R + Send + Sync + 'static,
-        R: Future<Output = Result<Response<B>, E>> + Send + 'static,
+        R: Future<Output = Result<Response<B>, EF>> + Send + 'static,
+        EF: Into<E>
     {
         self.add("/*", constants::ALL_POSSIBLE_HTTP_METHODS.to_vec(), handler)
     }
@@ -466,11 +477,12 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: HandlerError> RouterBuilder
     /// # }
     /// # run();
     /// ```
-    pub fn any_method<H, R, P>(self, path: P, handler: H) -> Self
+    pub fn any_method<H, R, P, EF>(self, path: P, handler: H) -> Self
     where
         P: Into<String>,
         H: FnMut(Request<hyper::Body>) -> R + Send + Sync + 'static,
-        R: Future<Output = Result<Response<B>, E>> + Send + 'static,
+        R: Future<Output = Result<Response<B>, EF>> + Send + 'static,
+        EF: Into<E>
     {
         self.add(path, constants::ALL_POSSIBLE_HTTP_METHODS.to_vec(), handler)
     }
@@ -496,11 +508,12 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: HandlerError> RouterBuilder
     /// # }
     /// # run();
     /// ```
-    pub fn add<P, H, R>(self, path: P, methods: Vec<Method>, handler: H) -> Self
+    pub fn add<P, H, R, EF>(self, path: P, methods: Vec<Method>, handler: H) -> Self
     where
         P: Into<String>,
         H: FnMut(Request<hyper::Body>) -> R + Send + Sync + 'static,
-        R: Future<Output = Result<Response<B>, E>> + Send + 'static,
+        R: Future<Output = Result<Response<B>, EF>> + Send + 'static,
+        EF: Into<E>
     {
         self.and_then(move |mut inner| {
             let mut path = path.into();
@@ -527,17 +540,18 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: HandlerError> RouterBuilder
     /// mod api {
     ///     use routerify::Router;
     ///     use hyper::{Response, Request, Body};
+    ///     use std::convert::Infallible;
     ///
-    ///     pub fn router() -> Router<Body, hyper::Error> {
+    ///     pub fn router() -> Router<Body, Infallible> {
     ///         Router::builder()
-    ///          .get("/users", |req| async move { Ok(Response::new(Body::from("User list"))) })
-    ///          .get("/books", |req| async move { Ok(Response::new(Body::from("Book list"))) })
+    ///          .get("/users", |req| async move { Ok::<_, Infallible>(Response::new(Body::from("User list"))) })
+    ///          .get("/books", |req| async move { Ok::<_, Infallible>(Response::new(Body::from("Book list"))) })
     ///          .build()
     ///          .unwrap()
     ///     }
     /// }
     ///
-    /// # fn run() -> Router<Body, hyper::Error> {
+    /// # fn run() -> Router<Body, std::convert::Infallible> {
     /// let router = Router::builder()
     ///     // Now, mount the api router at `/api` path.
     ///     .scope("/api", api::router())
@@ -643,9 +657,9 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: HandlerError> RouterBuilder
     /// # fn run() -> Router<Body, Infallible> {
     /// let router = Router::builder()
     ///      // Create and attach a pre middleware.
-    ///      .middleware(Middleware::pre(|req| async move { /* Do some operations */ Ok(req) }))
+    ///      .middleware(Middleware::pre(|req| async move { /* Do some operations */ Ok::<_, Infallible>(req) }))
     ///      // Create and attach a post middleware.
-    ///      .middleware(Middleware::post(|res| async move { /* Do some operations */ Ok(res) }))
+    ///      .middleware(Middleware::post(|res| async move { /* Do some operations */ Ok::<_, Infallible>(res) }))
     ///      .build()
     ///      .unwrap();
     /// # router

--- a/src/service/router_service.rs
+++ b/src/service/router_service.rs
@@ -93,7 +93,7 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: HandlerError> RouterService
                 constants::HEADER_NAME_X_POWERED_BY,
                 HeaderValue::from_static(constants::HEADER_VALUE_X_POWERED_BY),
             );
-            Ok(res)
+            Ok::<_, E>(res)
         })
         .unwrap();
 
@@ -124,7 +124,7 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: HandlerError> RouterService
 
         if let Some(router) = Self::downcast_router_to_hyper_body_type(router) {
             let options_route: Route<hyper::Body, E> = Route::new("/*", options_method, |_req| async move {
-                Ok(Response::builder()
+                Ok::<_, E>(Response::builder()
                     .status(StatusCode::NO_CONTENT)
                     .body(hyper::Body::empty())
                     .expect("Couldn't create the default OPTIONS response"))
@@ -153,7 +153,7 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: HandlerError> RouterService
         if let Some(router) = Self::downcast_router_to_hyper_body_type(router) {
             let default_404_route: Route<hyper::Body, E> =
                 Route::new("/*", constants::ALL_POSSIBLE_HTTP_METHODS.to_vec(), |_req| async move {
-                    Ok(Response::builder()
+                    Ok::<_, E>(Response::builder()
                         .status(StatusCode::NOT_FOUND)
                         .header(header::CONTENT_TYPE, "text/plain")
                         .body(hyper::Body::from(StatusCode::NOT_FOUND.canonical_reason().unwrap()))

--- a/src/types/route_params.rs
+++ b/src/types/route_params.rs
@@ -33,7 +33,7 @@ impl RouteParams {
     /// use routerify::{Router, RouteParams};
     /// use routerify::ext::RequestExt;
     /// use hyper::{Response, Body};
-    /// # use std::convert::Infallible;
+    /// use std::convert::Infallible;
     ///
     /// # fn run() -> Router<Body, Infallible> {
     /// let router = Router::builder()
@@ -43,7 +43,7 @@ impl RouteParams {
     ///         let user_name = params.get("userName").unwrap();
     ///         let book_name = params.get("bookName").unwrap();
     ///
-    ///         Ok(Response::new(Body::from(format!("Username: {}, Book Name: {}", user_name, book_name))))
+    ///         Ok::<_, Infallible>(Response::new(Body::from(format!("Username: {}, Book Name: {}", user_name, book_name))))
     ///      })
     ///      .build()
     ///      .unwrap();
@@ -63,7 +63,7 @@ impl RouteParams {
     /// use routerify::{Router, RouteParams};
     /// use routerify::ext::RequestExt;
     /// use hyper::{Response, Body};
-    /// # use std::convert::Infallible;
+    /// use std::convert::Infallible;
     ///
     /// # fn run() -> Router<Body, Infallible> {
     /// let router = Router::builder()
@@ -71,9 +71,9 @@ impl RouteParams {
     ///         let params: &RouteParams = req.params();
     ///         
     ///         if params.has("userName") {
-    ///             Ok(Response::new(Body::from(params.get("userName").unwrap().to_string())))
+    ///             Ok::<_, Infallible>(Response::new(Body::from(params.get("userName").unwrap().to_string())))
     ///         } else {
-    ///             Ok(Response::new(Body::from("username is not provided")))
+    ///             Ok::<_, Infallible>(Response::new(Body::from("username is not provided")))
     ///         }
     ///      })
     ///      .build()

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4,14 +4,15 @@ use routerify::prelude::RequestExt;
 use routerify::Router;
 use std::io;
 use std::sync::{Arc, Mutex};
+use std::convert::Infallible;
 
 mod support;
 
 #[tokio::test]
 async fn can_perform_simple_get_request() {
     const RESPONSE_TEXT: &str = "Hello world";
-    let router: Router<Body, routerify::Error> = Router::builder()
-        .get("/", |_| async move { Ok(Response::new(RESPONSE_TEXT.into())) })
+    let router: Router<Body, Infallible> = Router::builder()
+        .get("/", |_| async move { Ok::<_, Infallible>(Response::new(RESPONSE_TEXT.into())) })
         .build()
         .unwrap();
     let serve = serve(router).await;


### PR DESCRIPTION
Builds on #1 

This relaxes the error type constraints on handler methods (middleware and routes) to only require convertibility to the Router's global error type.

This would allow different portions of an API to use different error types, provided they are all convertible to a single aggregator type.

The downside of this change is that handlers defined as closures may require explicit type-hinting of the error type, whereas previously this could be inferred from the Router.